### PR TITLE
WebPack configuration for UMD builds allowed to be overriden with a local file

### DIFF
--- a/src/ngm/tasks/bundle-umd.task.ts
+++ b/src/ngm/tasks/bundle-umd.task.ts
@@ -1,4 +1,5 @@
 import path = require('path');
+import fs = require('fs');
 import { ROOT } from 'npm-submodules';
 import { getWebpackConfig } from '../models/webpack-umd.config';
 const webpack = require('webpack');
@@ -18,13 +19,19 @@ const webpackOutputOptions = {
 
 // export function bundleUmd(dir, moduleConf, minify) {
 export function bundleUmd({src, dist, name, main, tsconfig, minify}) {
-  const config = getWebpackConfig({
+   let local = {};
+
+  if (fs.existsSync('./webpack.config.js')) {
+    local = require(path.join(process.cwd(), 'webpack.config.js'));
+  }
+
+  const config = Object.assign(getWebpackConfig({
     name: !minify ? `${name}.umd` : `${name}.umd.min`,
     root: path.resolve(ROOT, src),
     entry: path.resolve(ROOT, src, main),
     output: path.resolve(dist, bundlesDir),
     tsconfig: tsconfig
-  });
+  }), local);
 
   if (minify) {
     config.plugins.unshift(new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
Hey guys. I'm trying to make your `ng2-file-upload` module with UMD running in ES5 environment and there's a tiny naming issue that you don't handle. You use `@angular.*` regexp as external dependency but the problem is that in UDM it's addressed as `ng.*`. Same goes to Rx.

If you look at angular repo itself you'll find that they use rollup as a builder and they place name conversion configuration files for every module independently. This patch lets you do the same with `nmg`. To solve the issue with `ng2-file-upload` for instance this is the expected content of such file:

```javascript
module.exports = {
  externals: {
    '@angular/common': 'ng.common',
    '@angular/core': 'ng.core'
  }
}
```